### PR TITLE
Fix compilation of lib_pq when lib_openssl is absent

### DIFF
--- a/src/interfaces/libpq/CMakeLists.txt
+++ b/src/interfaces/libpq/CMakeLists.txt
@@ -8,7 +8,7 @@ include_directories(BEFORE
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
 if(USE_OPENSSL)
-	set(pq_ssl_SRCS fe-secure-openssl.c ${PROJECT_SOURCE_DIR}/src/common/sha2_openssl.c)
+	set(pq_ssl_SRCS fe-secure-common.c fe-secure-openssl.c ${PROJECT_SOURCE_DIR}/src/common/sha2_openssl.c)
 else()
     set(pq_ssl_SRCS ${PROJECT_SOURCE_DIR}/src/common/sha2.c)
 endif()
@@ -26,7 +26,6 @@ set(pq_SRCS
 	fe-secure.c
 	libpq-events.c
     fe-auth-scram.c
-    fe-secure-common.c
 
 	${PORT_DIR}/chklocale.c
 	${PORT_DIR}/erand48.c


### PR DESCRIPTION
When lib_pq compiles without lib_openssl, there is link error due to compilation of fe-secure-common.c
This file should not be compiled. Original Makefile looks like:

...
ifeq ($(with_openssl),yes)
OBJS += fe-secure-openssl.o fe-secure-common.o
endif
...

The fix in this commit brings CMakeLists.txt into agreement with Makefile.